### PR TITLE
Recobrimento universal

### DIFF
--- a/Alg.Top-Wiki.tex
+++ b/Alg.Top-Wiki.tex
@@ -74,6 +74,7 @@
 \input{conteudo/grupo-fundamental}
 \input{conteudo/espaco-de-recobrimento}
 \input{conteudo/ações-de-grupos-e-recobrimentos}
+\input{conteudo/seifert-van-kampen}
 \input{conteudo/categorias}
 \input{conteudo/retração}
 \input{conteudo/homologia}

--- a/conteudo/ações-de-grupos-def.tex
+++ b/conteudo/ações-de-grupos-def.tex
@@ -36,6 +36,7 @@ Além disso, escrevemos $G\circlearrowright X$ para denotar que $G$ age em $X$.
 
 \begin{titlemize}{Lista de consequências}
 	\item \hyperref[ações-de-grupo-propriamente-descontínuas-def]{Definição de ação de grupo propriamente descontínua}; %'consequencia1' é o label onde o conceito Consequência 1 aparece
+    	\item \hyperref[automorfismo-de-recobrimento-def]{Automorfismo de um recobrimento};
 \end{titlemize}
 
 %[Bianca]: é mais fácil criar a lista de dependências do que a de consequências.

--- a/conteudo/espace-de-recobrimento-def.tex
+++ b/conteudo/espace-de-recobrimento-def.tex
@@ -54,4 +54,5 @@ denotamos intervalo aberto $(x_0+\frac{2k-1}{2},x_0+\frac{2k+1}{2})$ por $V_k.$ 
  	\item \hyperref[base-para-topologias-em-recobrimento-prop]{Base para as topologias em um recobrimento};\\
   	\item \hyperref[homomorfismo-induzido-por-recobrimento-prop]{Homomorfismo induzido por recobrimento é injetor};\\
    	\item \hyperref[recobrimento-1-conexo-prop]{Recobrimento 1-conexo quando X slsc}
+        \item \hyperref[morfismo-de-recobrimento-def]{Morfismo de recobrimento}
 \end{titlemize}

--- a/conteudo/espaco-de-recobrimento-morfismo-de-recobrimento-def.tex
+++ b/conteudo/espaco-de-recobrimento-morfismo-de-recobrimento-def.tex
@@ -2,7 +2,7 @@
 \label{morfismo-de-recobrimento-def}
 \begin{titlemize}{Lista de dependências}
 	\item \hyperref[espaco-de-recobrimento-def]{Espaço de recobrimento};\\
-	\item \hyperref[levantamento-de-funcoes]{Levantamento de funções};
+	\item \hyperref[levantamento-de-funções]{Levantamento de funções};
 \end{titlemize}
 \begin{defi}[Morfismo de recobrimento]
 	Um morfismo de recobrimento entre dois recobrimentos $p_1:E_1\longrightarrow X$ e $p_2:E_2\longrightarrow X$ é uma aplicação contínua $\phi:E_1\longrightarrow E_2$ tal que $p_2\circ\phi = p_1$.

--- a/conteudo/espaco-de-recobrimento-morfismo-de-recobrimento-def.tex
+++ b/conteudo/espaco-de-recobrimento-morfismo-de-recobrimento-def.tex
@@ -1,0 +1,35 @@
+\subsection{Morfismo de recobrimento}
+\label{morfismo-de-recobrimento-def}
+\begin{titlemize}{Lista de dependências}
+	\item \hyperref[espaco-de-recobrimento-def]{Espaço de recobrimento};\\
+	\item \hyperref[levantamento-de-funcoes]{Levantamento de funções};
+\end{titlemize}
+\begin{defi}[Morfismo de recobrimento]
+	Um morfismo de recobrimento entre dois recobrimentos $p_1:E_1\longrightarrow X$ e $p_2:E_2\longrightarrow X$ é uma aplicação contínua $\phi:E_1\longrightarrow E_2$ tal que $p_2\circ\phi = p_1$.
+\end{defi}
+
+\[\begin{tikzcd}
+	{E_1} && {E_2} \\
+	\\
+	& X
+	\arrow["\phi"', from=1-1, to=1-3]
+	\arrow["{p_1}", from=1-1, to=3-2]
+	\arrow["{p_2}"', from=1-3, to=3-2]
+\end{tikzcd}\]
+
+Note que $\phi$ é um levantamento de $p_1$ para o recobrimento $p_2:E_2\longrightarrow X$.
+
+\[\begin{tikzcd}
+	&& {E_2} \\
+	\\
+	{E_1} && X
+	\arrow["{p_2}"', from=1-3, to=3-3]
+	\arrow["\phi"', from=3-1, to=1-3]
+	\arrow["{p_1}", from=3-1, to=3-3]
+\end{tikzcd}\]
+
+Logo, assumindo que $E_1$ é conexo por caminhos, temos que se $\phi_1$ e $\phi_2$ são morfismos de recobrimento, então $\phi_1 = \phi_2 \Longleftrightarrow \phi(e_o) = \phi(e_0)$. Além disso, $p_{1*}(\pi_1(E_1,e_o))$ é um subgrupo de $p_{2*}(\pi_1(E_2,e_o))$.
+
+\begin{titlemize}{Lista de consequências}
+	\item \hyperref[recobrimento-universal]{Recobrimento universal};
+\end{titlemize}

--- a/conteudo/espaco-de-recobrimento-morfismo-de-recobrimento-def.tex
+++ b/conteudo/espaco-de-recobrimento-morfismo-de-recobrimento-def.tex
@@ -2,7 +2,7 @@
 \label{morfismo-de-recobrimento-def}
 \begin{titlemize}{Lista de dependências}
 	\item \hyperref[espaco-de-recobrimento-def]{Espaço de recobrimento};\\
-	\item \hyperref[levantamento-de-funções]{Levantamento de funções};
+	\item \hyperref[levantamento-de-funções-prop]{Levantamento de funções};
 \end{titlemize}
 \begin{defi}[Morfismo de recobrimento]
 	Um morfismo de recobrimento entre dois recobrimentos $p_1:E_1\longrightarrow X$ e $p_2:E_2\longrightarrow X$ é uma aplicação contínua $\phi:E_1\longrightarrow E_2$ tal que $p_2\circ\phi = p_1$.

--- a/conteudo/espaco-de-recobrimento-recobrimento-1-conexo-thm.tex
+++ b/conteudo/espaco-de-recobrimento-recobrimento-1-conexo-thm.tex
@@ -158,4 +158,5 @@
 \begin{titlemize}{Lista de consequências}
 	\item \hyperref[pertence-a-base-se-e-somente-se-possui-i-trivial]{Proposição - nova descrição da base $\mathcal{B}$};\\ %'consequencia1' é o label onde o conceito Consequência 1 aparece
     %\item \hyperref[espaço-1-conexo-def]{Espaço 1-conexo}
+    \item \hyperref[recobrimento-universal]{Recobrimento universal}
 \end{titlemize}

--- a/conteudo/espaco-de-recobrimento-recobrimento-universal.tex
+++ b/conteudo/espaco-de-recobrimento-recobrimento-universal.tex
@@ -43,6 +43,5 @@ O resultado anterior motiva a seguinte definição.
 \end{defi}
 
 \begin{titlemize}{Lista de consequências}
-	\item \hyperref[consequencia1]{Consequência 1};\\
-	\item \hyperref[]{}
+	\item \hyperref[teorema-de-seifert-van-kampen]{Teorema de Seifert-Van Kampen};
 \end{titlemize}

--- a/conteudo/espaco-de-recobrimento-recobrimento-universal.tex
+++ b/conteudo/espaco-de-recobrimento-recobrimento-universal.tex
@@ -1,0 +1,48 @@
+\subsection{Recobrimento universal}
+\label{recobrimento-universal}
+\begin{titlemize}{Lista de dependências}
+	\item \hyperref[morfismo-de-recobrimento-def]{Morfismo de recobrimento};\\
+    \item \hyperref[recobrimento-1-conexo-prop]{Recobrimento 1-conexo quando X slsc};
+\end{titlemize}
+Nesta subseção iremos assumir que o espaço base $X$ é razoável, isto é, $X$ é conexo, localmente conexo por caminhos e localmente semi-simplesmente conexo.
+\begin{af}[Morfismos de recobrimento são recobrimentos]
+	Sejam $p_1:E_1 \longrightarrow X$ e $p_2:E_2 \longrightarrow X$ dois recobrimentos 0-conexos. Dado um morfismo de recobrimentos $\phi:E_1 \longrightarrow E_2$, então $\phi$ é um recobrimento.
+\end{af}
+
+\begin{thm}[O recobrimento 1-conexo é universal]
+    Sejam $q_X:(\tilde X, \tilde x_0) \longrightarrow (X,x_0)$ um recobrimento 1-conexo e $p:(E,e_0) \longrightarrow (X,x_0)$ um recobrimento 0-conexo, existe um único recobrimento $q_E:(\tilde X, \tilde x_0) \longrightarrow (E,e_0)$ tal que:
+\end{thm}
+\[\begin{tikzcd}
+	{(\tilde X, \tilde x_0)} \\
+	\\
+	&& {(E,e_0)} \\
+	\\
+	{(X,x_0)}
+	\arrow["{q_E}"', from=1-1, to=3-3]
+	\arrow["{q_X}", from=1-1, to=5-1]
+	\arrow["p"', from=3-3, to=5-1]
+\end{tikzcd}\]
+
+\begin{dem}
+    Note que $q_E$ é levantamento de $q_X$ para o recobrimento $p:(E,e_0) \longrightarrow (X,x_0)$, tal levantamento existe pelo critério de existência de levantamentos de funções, pois $$q_{X*}(\pi_1(\tilde X, \tilde x_0)) = \{1\} < p_*(\pi_1(E, e_0)).$$
+    
+    Como estamos trabalhando no contexto de recobrimentos pontuados, segue que para qualquer $\tilde q_E:(\tilde X, \tilde x_0) \longrightarrow (E, e_0)$ vale: $$q_E(\tilde x_0) = e_0 = \tilde q_E(\tilde x_0)$$
+    donde segue a unicidade.
+\end{dem}
+
+Note que este teorema nos mostra que o recobrimento 1-conexo de $X$ também é um recobrimento 1-conexo para todos os recobrimentos 0-conexos de X.
+
+\begin{corol}[Unicidade do recobrimento 1-conexo]
+    Se $(\tilde X, \tilde x_0) \longrightarrow (X, x_0)$ e $(\overline{X}, \overline{x}_0) \longrightarrow (X, x_0)$ são recobrimentos 1-conexos, então existe um único isomorfismo entre $(\tilde X, \tilde x_0)$ e $(\overline{X}, \overline{x}_0)$.
+\end{corol}
+
+O resultado anterior motiva a seguinte definição.
+
+\begin{defi}[Recobrimento universal]
+    Seja X um espaço razoável, então o seu recobrimento 1-conexo é chamado de recobrimento universal de X.
+\end{defi}
+
+\begin{titlemize}{Lista de consequências}
+	\item \hyperref[consequencia1]{Consequência 1};\\
+	\item \hyperref[]{}
+\end{titlemize}

--- a/conteudo/espaco-de-recobrimento.tex
+++ b/conteudo/espaco-de-recobrimento.tex
@@ -11,8 +11,13 @@ Na topologia algébrica, espaços de recobrimento estão intimamente relacionado
 \input{conteudo/espace-de-recobrimento-def}
 \input{conteudo/levantamento-de-caminhos-prop}
 \input{conteudo/levantamento-de-homotopia-prop}
+\input{conteudo/localmente-conexo-por-caminhos-def}
+\input{conteudo/localmente-conexo-por-caminhos-ex}
+\input{conteudo/levantamento-de-funções}
 \input{conteudo/grupo-fundamental-de-espaco-projetivo-ex}
 \input{conteudo/grupo-fundamental-de-S1-prop}
+\input{conteudo/teo-borsuk-ulam-prop}
+\input{conteudo/teo-borsuk-ulam-corol-prop}
 \input{conteudo/espaco-de-recobrimento-recobrimento-1-conexo-e-P(X,x)}
 \input{conteudo/espaco-de-recobrimento-bases-para-os-espacos}
 \input{conteudo/espaco-de-recobrimento-recobrimento-1-conexo-lema}

--- a/conteudo/espaco-de-recobrimento.tex
+++ b/conteudo/espaco-de-recobrimento.tex
@@ -19,6 +19,8 @@ Na topologia algébrica, espaços de recobrimento estão intimamente relacionado
 \input{conteudo/espaco-de-recobrimento-recobrimento-1-conexo-thm}
 \input{conteudo/espaco-de-recobrimento-recobrimento-1-conexo-descricao-da-base}
 \input{conteudo/espaco-de-recobrimento-recobrimento-1-conexo-prop}
+\input{conteudo/espaco-de-recobrimento-morfismo-de-recobrimento-def}
+\input{conteudo/espaco-de-recobrimento-recobrimento-universal}
 %%% Local Variables:
 %%% mode: LaTeX
 %%% TeX-master: "../Alg.Top-Wiki"

--- a/conteudo/levantamento-de-funções.tex
+++ b/conteudo/levantamento-de-funções.tex
@@ -80,8 +80,9 @@ Agora, passemos para o Teorema que garante uma condição necessária e suficien
      
 \end{dem}
 \begin{titlemize}{Lista de consequências}
-	\item \hyperref[teorema-borsuk-ulam]{Teorema de Borsuk-Ulam};\\ %'consequencia1' é o label onde o conceito Consequência 1 aparece
+	\item \hyperref[teo-borsuk-ulam-prop]{Teorema de Borsuk-Ulam};\\ %'consequencia1' é o label onde o conceito Consequência 1 aparece
 	%\item \hyperref[]{}
+ 	\item \hyperref[espaco-de-recobrimento-morfismo-de-recobrimento-def]{Morfismo de recobrimento};
 \end{titlemize}
 
 %[Bianca]: Um arquivo tex pode ter mais de uma afirmação (ou definição, ou exemplo), mas nesse caso cada afirmação deve ter seu próprio label. Dar preferência para agrupar afirmações que dependam entre sí de maneira próxima (um teorema e seu corolário, por exemplo)

--- a/conteudo/levantamento-de-funções.tex
+++ b/conteudo/levantamento-de-funções.tex
@@ -82,7 +82,7 @@ Agora, passemos para o Teorema que garante uma condição necessária e suficien
 \begin{titlemize}{Lista de consequências}
 	\item \hyperref[teo-borsuk-ulam-prop]{Teorema de Borsuk-Ulam};\\ %'consequencia1' é o label onde o conceito Consequência 1 aparece
 	%\item \hyperref[]{}
- 	\item \hyperref[espaco-de-recobrimento-morfismo-de-recobrimento-def]{Morfismo de recobrimento};
+ 	\item \hyperref[morfismo-de-recobrimento-def]{Morfismo de recobrimento};
 \end{titlemize}
 
 %[Bianca]: Um arquivo tex pode ter mais de uma afirmação (ou definição, ou exemplo), mas nesse caso cada afirmação deve ter seu próprio label. Dar preferência para agrupar afirmações que dependam entre sí de maneira próxima (um teorema e seu corolário, por exemplo)

--- a/conteudo/levantamento-de-funções.tex
+++ b/conteudo/levantamento-de-funções.tex
@@ -82,7 +82,8 @@ Agora, passemos para o Teorema que garante uma condição necessária e suficien
 \begin{titlemize}{Lista de consequências}
 	\item \hyperref[teo-borsuk-ulam-prop]{Teorema de Borsuk-Ulam};\\ %'consequencia1' é o label onde o conceito Consequência 1 aparece
 	%\item \hyperref[]{}
- 	\item \hyperref[morfismo-de-recobrimento-def]{Morfismo de recobrimento};
+ 	\item \hyperref[morfismo-de-recobrimento-def]{Morfismo de recobrimento};\\
+    	\item \hyperref[acao-de-automorfismos-e-livre-prop]{A ação do grupo de automorfismos é livre};
 \end{titlemize}
 
 %[Bianca]: Um arquivo tex pode ter mais de uma afirmação (ou definição, ou exemplo), mas nesse caso cada afirmação deve ter seu próprio label. Dar preferência para agrupar afirmações que dependam entre sí de maneira próxima (um teorema e seu corolário, por exemplo)

--- a/conteudo/levantamento-de-funções.tex
+++ b/conteudo/levantamento-de-funções.tex
@@ -83,7 +83,7 @@ Agora, passemos para o Teorema que garante uma condição necessária e suficien
 	\item \hyperref[teo-borsuk-ulam-prop]{Teorema de Borsuk-Ulam};\\ %'consequencia1' é o label onde o conceito Consequência 1 aparece
 	%\item \hyperref[]{}
  	\item \hyperref[morfismo-de-recobrimento-def]{Morfismo de recobrimento};\\
-    	\item \hyperref[acao-de-automorfismos-e-livre-prop]{A ação do grupo de automorfismos é livre};
+    	\item \hyperref[acao-de-automorfismos-e-livre-prop]{A ação do grupo de automorfismos é livre sobre as fibras};
 \end{titlemize}
 
 %[Bianca]: Um arquivo tex pode ter mais de uma afirmação (ou definição, ou exemplo), mas nesse caso cada afirmação deve ter seu próprio label. Dar preferência para agrupar afirmações que dependam entre sí de maneira próxima (um teorema e seu corolário, por exemplo)

--- a/conteudo/seifert-van-kampen-acao-de-automorfismo-transitiva-prop.tex
+++ b/conteudo/seifert-van-kampen-acao-de-automorfismo-transitiva-prop.tex
@@ -79,5 +79,6 @@ Reciprocamente, supondo que $q_*(\pi_1(E, e_0)) \triangleleft \pi_1(X, x_0)$, ve
 \end{thm}
 
 \begin{titlemize}{Lista de consequências}
-	\item \hyperref[g-recobrimentos-e-epimorfismos-prop]{G-recobrimentos 0-conexos e epimorfismos do grupo fundamental em G};
+	\item \hyperref[g-recobrimentos-e-epimorfismos-prop]{G-recobrimentos 0-conexos e epimorfismos do grupo fundamental em G};\\
+    	\item \hyperref[homomorfismos-e-g-recobrimentos-prop]{G-recobrimentos e homomorfismos do grupo fundamental em G};
 \end{titlemize}

--- a/conteudo/seifert-van-kampen-acao-de-automorfismo-transitiva-prop.tex
+++ b/conteudo/seifert-van-kampen-acao-de-automorfismo-transitiva-prop.tex
@@ -1,0 +1,84 @@
+\subsection{Quando a ação do grupo de automorfismos é transitiva sobre as fibras?}
+\label{acao-de-automorfismo-transitiva-prop}
+\begin{titlemize}{Lista de dependências}
+    \item \hyperref[levantamento-de-caminhos-prop]{Levantamento de caminhos};\\
+	\item \hyperref[automorfismo-de-recobrimento-def]{Automorfismo de um recobrimento};\\
+    \item \hyperref[acao-de-automorfismos-e-livre-prop]{A ação do grupo de automorfismos é livre};
+\end{titlemize}
+Seja $q:(E, e_0) \longrightarrow (X, x_0)$ um recobrimento 0-conexo pontuado e $D=Aut(E, q, X)$ o grupo de automorfismos desse recobrimento, queremos achar alguma condição necessária e suficiente para que a ação de $D$ seja transitiva sobre as fibras, ou seja, $\forall x \in X$ a ação $D \circlearrowright q^{-1}(x)$ é tal que $\forall e, e' \in q^{-1}(x)$ $\exists \phi \in D$ tal que $\phi(e) = e'$.
+
+Primeiramente, suponha que a ação $D \circlearrowright q^{-1}(x_0)$ é transitiva. Considere a função $\varphi_{e_0}:\pi_1(X, x_0) \longrightarrow D$, onde $\varphi_{e_0}([\alpha]) = d \Longleftrightarrow d \cdot e_0 = \tilde \alpha_{e_0}(1)$.
+
+\begin{af}
+    A função $\varphi_{e_0}$ acima está bem definida e é um homomorfismo sobrejetor.
+\end{af}
+
+\begin{dem}
+    Tome $[\alpha] \in \pi_1(X, x_0)$, como $\alpha(1) = x_0$, segue que $\tilde\alpha_{e_0}(1) \in q^{-1}(x_0)$, temos ainda que $e_0 \in q^{-1}(x_0)$, logo, como a ação $D \circlearrowright q^{-1}(x_0)$ é transitiva por hipótese, seque que $\exists d \in D$ tal que $d \cdot e_0 = \tilde\alpha_{e_0}(1)$.
+    
+    Vimos ainda que a ação $D \circlearrowright q^{-1}(x_0)$ é livre, donde segue que $d$ é único. Por fim, se $\alpha \sim \alpha'$ $rel$ $\partial I$, segue que $\tilde\alpha_{e_0}(1) = \tilde\alpha_{e_0}'(1)$, logo $\varphi_{e_0}$ não depende da escolha de representantes e está bem definida.
+
+    Tome $d \in D$, como $E$ é $0$-conexo, $\exists \gamma:I \longrightarrow E$ tal que $\gamma(0) = e_0$ e $\gamma(1) = d \cdot e_0$. Seja $\alpha := q \circ \gamma$, então por unicidade de levantamentos segue que $\tilde\alpha_{e_0} = \gamma$, donde $\varphi_{e_0}([\alpha]) = d$ e $\varphi_{e_0}$ é sobrejetora.
+
+    Por fim, tome $[\alpha], [\beta] \in \pi_1(X, x_0)$, então: $$\varphi_{e_0}([\alpha] \cdot [\beta]) = \varphi([\alpha*\beta])$$ e temos que: $$\widetilde{(\alpha * \beta)}_{e_0}(1) = (\tilde\alpha_{e_0}*\tilde\beta_{\tilde\alpha_{e_0}(1)})(1) = \tilde\beta_{\tilde\alpha_{e_0}(1)}(1).$$
+
+    Por outro lado, sejam $$d'e_0 = \tilde\alpha_{e_0}(1)$$ $$d''e_0 = \tilde\beta_{e_0}(1),$$ então veja que: $$\varphi_{e_0}([\alpha]) \cdot \varphi_{e_0}([\beta]) = d'd''$$ e que $$\tilde\beta_{\tilde\alpha_{e_0}(1)} = \tilde\beta_{d'e_0}$$
+
+    Note que: $$q \circ (d'\tilde\beta_{e_0}) = q \circ d' \circ \tilde\beta_{e_0} = q \circ \tilde\beta_{e_0} = \beta,$$ pois $d'$ é um automorfismo de recobrimento. Além disso: $$d'\tilde\beta_{e_0}(0) = d'e_0$$ de modo que, pela unicidade de levantamentos: $$\tilde\beta_{d'e_0} = d'\tilde\beta_{e_0}$$
+
+    Disso segue que: $$\widetilde{(\alpha * \beta)}_{e_0}(1) = \tilde\beta_{d'e_0}(1) = d'\tilde\beta_{e_0}(1) = d'd''e_0$$ e portanto: $$\varphi([\alpha]\cdot[\beta]) = d'd'' = \varphi_{e_0}([\alpha]) \cdot \varphi_{e_0}([\beta]).$$
+\end{dem}
+
+\begin{prop}
+    O kernel de $\varphi_{e_0}$ é $q_*(\pi_1(E, e_0))$.
+\end{prop}
+
+\begin{dem}
+Tome $[\alpha] \in Ker(\varphi_{e_0})$, então:\\
+    $$\begin{tabular}{l l}
+        $[\alpha] \in Ker(\varphi_{e_0})$ & $\Longleftrightarrow                                                     \tilde\alpha_{e_0}(1) = e_0$ \\
+                                        & $\Longleftrightarrow \tilde\alpha_{e_0} \in \Omega(E, e_0)$\\
+                                        & $\Longleftrightarrow [\tilde\alpha_{e_0}] \in \pi_1(E, e_0)$\\
+                                        & $\Longleftrightarrow [\alpha] \in Im(q_*)$
+    \end{tabular}$$\\
+    de modo que $Ker(\varphi_{e_0}) = q_*(\pi_1(E, e_0))$.
+\end{dem}
+
+Note que isso implica que $q_*(\pi_1(E, e_0)) \triangleleft \pi_1(X, x_0)$ e, ainda: $$D \cong \frac{\pi_1(X, x_0)}{q_*(\pi_1(E, e_0))}$$ pelo teorema de isomorfismos.
+
+Reciprocamente, supondo que $q_*(\pi_1(E, e_0)) \triangleleft \pi_1(X, x_0)$, veremos que $D \cong \frac{\pi_1(X, x_0)}{q_*(\pi_1(E, e_0))}$ e age transitivamente em $q^{-1}(x_0)$.
+
+\begin{af}
+    Nas condições acima, se $D$ age transitivamente em $q^{-1}(x_0)$, então age transitivamente em todas as fibras.
+\end{af}
+
+\begin{dem}
+    Como $X$ é conexo por caminhos, segue que $\pi_1(X, x_0) \cong \pi_1(X, x_1)$ $\forall x_1 \in X$, analogamente $\pi_1(E, e_0) \cong \pi_1(E, e_1)$ $\forall e_1 \in E$. Logo, dados $x_1 \in X$ e $e_1 \in E$ temos $\frac{\pi_1(X, x_0)}{q_*(\pi_1(E, e_0))} \cong D \cong \frac{\pi_1(X, x_1)}{q_*(\pi_1(E, e_1))}$ e, como $\frac{\pi_1(X, x_1)}{q_*(\pi_1(E, e_1))}$ age transitivamente em $q^{-1}(x_1)$, da arbitrariedade de $x_1$ segue que $D$ age transitivamente em todas as fibras.
+\end{dem}
+
+\begin{lemma}
+    Seja $G$ um grupo e suponha que a ação $G \circlearrowright E$ é propriamente descontínua, então $D \cong G$.
+\end{lemma}
+
+\begin{dem}
+    Seja $\psi:G \longrightarrow D$ a função dada por $\psi(g) = \psi_g$, onde $\psi_g$ é o homeomorfismo determinado pela ação do elemento g em X, $\psi$ é um homomorfismo por se tratar de uma ação.
+
+    Primeiro note que $\psi$ é injetor, afinal, se $\psi_g = Id$, então $g \cdot e = e$, de modo que $g = 1_G$, pois toda ação propriamente descontínua é livre. Além disso, $\psi$ é sobrejetor, afinal dado $\phi \in D$, sabemos que $$q(e_0) = (q \circ \phi)(e_0)$$ pois $\phi$ é automorfismo de recobrimentos. Portanto, $\exists g \in G$ tal que $\phi(e_0) = ge_0$. Logo, como ambos $\psi_g$ e $\phi$ sào levantamentos de $q$, segue da unicidade de levantamentos que $\psi_g = \phi$.
+\end{dem}
+
+\begin{af}
+    Vale que $(E, e_0) \cong (\frac{\tilde X}{q_*(\pi_1(E, e_0))}, \overline{[c_{x_0}]})$
+\end{af}
+
+\begin{af}
+    Seja $G = \frac{\pi_1(X, x_0)}{q_*(\pi_1(E, e_0))}$, então a ação $G \circlearrowright E$ dada por $$\overline{[\alpha]} \cdot \overline{[\gamma]} = \overline{[\alpha * \gamma]}$$ é propriamente descontínua com quociente $X$.
+\end{af}
+
+\begin{thm}[Condição necessária e suficiente para a ação do grupo de automorfismos ser transitiva sobre as fibras]
+	Se $q:E \longrightarrow X$ é um recobrimento $0$-conexo, então a ação $D \circlearrowright q^{-1}(x)$ é transitiva para todo $x \in X$ se, e somente se, $q_*(\pi_1(E, e_0)) \triangleleft \pi_1(X, x_0)$. Nesse caso: $$D \cong \frac{\pi_1(X, x_0)}{q_*(\pi_1(E, e_0))}$$
+\end{thm}
+
+\begin{titlemize}{Lista de consequências}
+	\item \hyperref[consequencia1]{Consequência 1};\\ %'consequencia1' é o label onde o conceito Consequência 1 aparece
+	\item \hyperref[]{}
+\end{titlemize}

--- a/conteudo/seifert-van-kampen-acao-de-automorfismo-transitiva-prop.tex
+++ b/conteudo/seifert-van-kampen-acao-de-automorfismo-transitiva-prop.tex
@@ -3,7 +3,7 @@
 \begin{titlemize}{Lista de dependências}
     \item \hyperref[levantamento-de-caminhos-prop]{Levantamento de caminhos};\\
 	\item \hyperref[automorfismo-de-recobrimento-def]{Automorfismo de um recobrimento};\\
-    \item \hyperref[acao-de-automorfismos-e-livre-prop]{A ação do grupo de automorfismos é livre};
+    \item \hyperref[acao-de-automorfismos-e-livre-prop]{A ação do grupo de automorfismos é livre sobre as fibras};
 \end{titlemize}
 Seja $q:(E, e_0) \longrightarrow (X, x_0)$ um recobrimento 0-conexo pontuado e $D=Aut(E, q, X)$ o grupo de automorfismos desse recobrimento, queremos achar alguma condição necessária e suficiente para que a ação de $D$ seja transitiva sobre as fibras, ou seja, $\forall x \in X$ a ação $D \circlearrowright q^{-1}(x)$ é tal que $\forall e, e' \in q^{-1}(x)$ $\exists \phi \in D$ tal que $\phi(e) = e'$.
 

--- a/conteudo/seifert-van-kampen-acao-de-automorfismo-transitiva-prop.tex
+++ b/conteudo/seifert-van-kampen-acao-de-automorfismo-transitiva-prop.tex
@@ -79,6 +79,5 @@ Reciprocamente, supondo que $q_*(\pi_1(E, e_0)) \triangleleft \pi_1(X, x_0)$, ve
 \end{thm}
 
 \begin{titlemize}{Lista de consequências}
-	\item \hyperref[consequencia1]{Consequência 1};\\ %'consequencia1' é o label onde o conceito Consequência 1 aparece
-	\item \hyperref[]{}
+	\item \hyperref[g-recobrimentos-e-epimorfismos-prop]{G-recobrimentos 0-conexos e epimorfismos do grupo fundamental em G};
 \end{titlemize}

--- a/conteudo/seifert-van-kampen-acao-de-automorfismos-e-livre-prop.tex
+++ b/conteudo/seifert-van-kampen-acao-de-automorfismos-e-livre-prop.tex
@@ -1,0 +1,27 @@
+\subsection{A açào do grupo de automorfismos é livre}
+\label{acao-de-automorfismos-e-livre-prop}
+\begin{titlemize}{Lista de dependências}
+	\item \hyperref[levantamento-de-funções-prop]{Levantamento de funções};\\
+	\item \hyperref[automorfismo-de-recobrimento-def]{Automorfismo de um recobrimento};
+\end{titlemize}
+\begin{prop}[Nome da Afirmação]
+	Dado um recobrimento $q:E \longrightarrow X$ $0$-conexo, então a ação $Aut(E, q, X) \circlearrowright q^{-1}(x)$ é livre para todo $x \in X$. Ou seja, $\forall x \in X$ $\forall e \in q^{-1}(x)$, $\phi \cdot e = e \Longrightarrow \phi = Id$.\\
+\end{prop}
+
+\begin{dem}
+    Note que $\phi$ é um levantamento de $q$, logo, como $E$ é conexo e $Id:E \longrightarrow E$ também é um levantamento de q, pela unicidade de levantamentos, segue que dados $x \in X$ e $e \in q^{-1}(x)$, então $$\phi \cdot e = e \Longrightarrow \phi(e) = Id(e) \Longrightarrow \phi = Id$$
+    % https://q.uiver.app/#q=WzAsNCxbMiwwLCJFIl0sWzIsMiwiWCJdLFswLDIsIkUiXSxbMSw0LCJcXGJ1bGxldCJdLFsyLDAsIklkIiwyXSxbMiwwLCJcXHBoaSIsMCx7Im9mZnNldCI6LTN9XSxbMCwxLCJwIiwyXSxbMiwxLCJwIiwyXV0=
+    \[\begin{tikzcd}
+    	&& E \\
+    	\\
+    	E && X \\
+    	\arrow["q"', from=1-3, to=3-3]
+    	\arrow["Id"', from=3-1, to=1-3]
+    	\arrow["\phi", shift left=3, from=3-1, to=1-3]
+    	\arrow["q"', from=3-1, to=3-3]
+    \end{tikzcd}\]
+\end{dem}
+
+\begin{titlemize}{Lista de consequências}
+	\item \hyperref[acao-de-automorfismo-transitiva-prop]{Quando a ação do grupo de auitomorfismos é transitiva sobre as fibras?};
+\end{titlemize}

--- a/conteudo/seifert-van-kampen-acao-de-automorfismos-e-livre-prop.tex
+++ b/conteudo/seifert-van-kampen-acao-de-automorfismos-e-livre-prop.tex
@@ -1,4 +1,4 @@
-\subsection{A açào do grupo de automorfismos é livre}
+\subsection{A açào do grupo de automorfismos é livre sobre as fibras}
 \label{acao-de-automorfismos-e-livre-prop}
 \begin{titlemize}{Lista de dependências}
 	\item \hyperref[levantamento-de-funções-prop]{Levantamento de funções};\\

--- a/conteudo/seifert-van-kampen-acao-de-automorfismos-e-livre-prop.tex
+++ b/conteudo/seifert-van-kampen-acao-de-automorfismos-e-livre-prop.tex
@@ -23,5 +23,6 @@
 \end{dem}
 
 \begin{titlemize}{Lista de consequências}
-	\item \hyperref[acao-de-automorfismo-transitiva-prop]{Quando a ação do grupo de auitomorfismos é transitiva sobre as fibras?};
+	\item \hyperref[acao-de-automorfismo-transitiva-prop]{Quando a ação do grupo de auitomorfismos é transitiva sobre as fibras?};\\
+   	\item \hyperref[g-recobrimentos-e-epimorfismos-prop]{G-recobrimentos 0-conexos e epimorfismos do grupo fundamental em G};
 \end{titlemize}

--- a/conteudo/seifert-van-kampen-acao-de-automorfismos-e-livre-prop.tex
+++ b/conteudo/seifert-van-kampen-acao-de-automorfismos-e-livre-prop.tex
@@ -24,5 +24,6 @@
 
 \begin{titlemize}{Lista de consequências}
 	\item \hyperref[acao-de-automorfismo-transitiva-prop]{Quando a ação do grupo de auitomorfismos é transitiva sobre as fibras?};\\
-   	\item \hyperref[g-recobrimentos-e-epimorfismos-prop]{G-recobrimentos 0-conexos e epimorfismos do grupo fundamental em G};
+   	\item \hyperref[g-recobrimentos-e-epimorfismos-prop]{G-recobrimentos 0-conexos e epimorfismos do grupo fundamental em G};\\
+    	\item \hyperref[homomorfismos-e-g-recobrimentos-prop]{G-recobrimentos e homomorfismos do grupo fundamental em G};
 \end{titlemize}

--- a/conteudo/seifert-van-kampen-automorfismo-de-recobrimento-def.tex
+++ b/conteudo/seifert-van-kampen-automorfismo-de-recobrimento-def.tex
@@ -18,7 +18,7 @@
 Denotamos o grupo formado por todos os automorfismos de um recobrimento, também chamado de grupo de transformações de Deck, por $Aut(E, q, X)$. Por definição, para todo $x \in X$, a ação $D \circlearrowright q^{-1}(x)$ é dada por $$\phi \cdot e = \phi(e)$$
 
 \begin{titlemize}{Lista de consequências}
-	\item \hyperref[acao-de-automorfismos-e-livre-prop]{A ação do grupo de automorfismos é livre};\\
+	\item \hyperref[acao-de-automorfismos-e-livre-prop]{A ação do grupo de automorfismos é livre sobre as fibras};\\
     \item \hyperref[acao-de-automorfismo-transitiva-prop]{Quando a ação do grupo de automorfismos é transitiva sobre as fibras?};\\
     \item \hyperref[g-recobrimento-regular-def]{G-recobrimento regular};
 \end{titlemize}

--- a/conteudo/seifert-van-kampen-automorfismo-de-recobrimento-def.tex
+++ b/conteudo/seifert-van-kampen-automorfismo-de-recobrimento-def.tex
@@ -1,0 +1,24 @@
+\subsection{Automorfismo de um recobrimento}
+\label{automorfismo-de-recobrimento-def}
+\begin{titlemize}{Lista de dependências}
+	\item \hyperref[ações-de-grupo-def]{Ações de grupo};
+\end{titlemize}
+\begin{defi}[Automorfismo de um recobrimento]
+    Um automorfismo de um recobrimento $q:E \longrightarrow X$ é um homeomorfismo $\phi:E \longrightarrow E$ tal que:
+    \[\begin{tikzcd}
+	E && E \\
+	\\
+	& X
+	\arrow["\phi", from=1-1, to=1-3]
+	\arrow["q"', from=1-1, to=3-2]
+	\arrow["q", from=1-3, to=3-2]
+    \end{tikzcd}\]
+\end{defi}
+
+Denotamos o grupo formado por todos os automorfismos de um recobrimento, também chamado de grupo de transformações de Deck, por $Aut(E, q, X)$. Por definição, para todo $x \in X$, a ação $D \circlearrowright q^{-1}(x)$ é dada por $$\phi \cdot e = \phi(e)$$
+
+\begin{titlemize}{Lista de consequências}
+	\item \hyperref[acao-de-automorfismos-e-livre-prop]{A ação do grupo de automorfismos é livre};\\
+    \item \hyperref[acao-de-automorfismo-transitiva-prop]{Quando a ação do grupo de automorfismos é transitiva sobre as fibras?};\\
+    \item \hyperref[g-recobrimento-regular-def]{G-recobrimento regular};
+\end{titlemize}

--- a/conteudo/seifert-van-kampen-colagem-de-recobrimentos.tex
+++ b/conteudo/seifert-van-kampen-colagem-de-recobrimentos.tex
@@ -1,0 +1,23 @@
+\subsection{Colagem de recobrimentos}
+\label{colagem-de-recobrimentos-prop}
+\begin{titlemize}{Lista de dependências}
+	\item \hyperref[espaco-de-recobrimento]{Espaço de recobrimento};
+\end{titlemize}
+Suponha que $X$ é uma união the dois conjuntos abertos $U$ e $V$. Um recobrimento de $X$ se restringe a $U$ e $V$ gerando dois recobrimentos isomorfos em $U \cap V$. Queremos realizar o processo inverso.
+\begin{thm}[Colagem de recobrimentos] 
+	Sejam $q_1: E_1 \longrightarrow U$ e $q_2: E_2 \longrightarrow V$ recobrimentos e seja $\varphi: q_1^{-1}(U \cap V) \longrightarrow q_2^{-1}(U \cap V)$ um isomorfismo de recobrimentos sobre $U \cap V$. Então é possível "colar" os recobrimentos de forma a obter um recobrimento $q:E \longrightarrow X$ junto de dois isomorfismos de recobrimentos $\varphi_1:E_1 \longrightarrow q^{-1}(U)$  e $\varphi_2:E_2 \longrightarrow q^{-1}(V)$ tais que, em $U \cap V$, $\varphi = \varphi_2^{-1} \circ \varphi_1$.
+\end{thm}
+
+\begin{dem}
+    Podemos construir o conjunto $E$ como o espaço quociente da união disjunta $E_1 \sqcup E_2$ pela relação de equivalência que identifica um ponto $e_1 \in q_1^{-1}(U \cap V)$ com o ponto $\varphi(e_1) \in q_2^{-1}(U \cap v)$. Como $\varphi$ é compatível com mapas para $X$, obtemos um mapa $q:E \longrightarrow X$.
+
+    Como o mapa de $E_1$ para $E$ é um homeomorfismo sobre sua imagem $q^{-1}(U)$, que é aberta em $E$, segue que a restrição de $q$ à imagem inversa de $U$ é isomorfa à $E_1 \longrightarrow U$, similarmente, similarmente, a restrição sobre a imagem inversa de $V$ é isomorfa à $Y_2 \longrightarrow V$. Disso, segue que $q:E \longrightarrow X$ é um recobrimento.
+\end{dem}
+
+\begin{corol}
+    Se $q_1:E_1 \longrightarrow U$ e $q_2:E_2 \longrightarrow V$ forem $G$-recobrimentos regulares, então $q:E \longrightarrow X$ tem uma única estrutura de $G$-recobrimento regular tal que os mapas de $E_1$ e $E_2$ comutam com a ação de $G$.
+\end{corol}
+
+\begin{titlemize}{Lista de consequências}
+	\item \hyperref[seifert-van-kampen-prop]{Teorema de Seifert-Van Kampen};
+\end{titlemize}

--- a/conteudo/seifert-van-kampen-correspondencia-entre-epimorfismos-e-g-recobrimentos.tex
+++ b/conteudo/seifert-van-kampen-correspondencia-entre-epimorfismos-e-g-recobrimentos.tex
@@ -43,6 +43,5 @@ Antes de enunciar o teorema, lembramos que um modelo conjuntista para o recobrim
 \end{dem}
 
 \begin{titlemize}{Lista de consequências}
-	\item \hyperref[consequencia1]{Consequência 1};\\ %'consequencia1' é o label onde o conceito Consequência 1 aparece
-	\item \hyperref[]{}
+	\item \hyperref[homomorfismos-e-g-recobrimentos-prop]{G-recobrimentos e homomorfismos do grupo fundamental em G};
 \end{titlemize}

--- a/conteudo/seifert-van-kampen-correspondencia-entre-epimorfismos-e-g-recobrimentos.tex
+++ b/conteudo/seifert-van-kampen-correspondencia-entre-epimorfismos-e-g-recobrimentos.tex
@@ -1,0 +1,48 @@
+\subsection{G-recobrimentos 0-conexos e epimorfismos do grupo fundamental em G}
+\label{g-recobrimentos-e-epimorfismos-prop}
+\begin{titlemize}{Lista de dependências}
+    \item \hyperref[recobrimento-1-conexo-em-bijecao-com-P(X,x)]{Recobrimento 1-conexo em bijeção com $P(X, x_0)$};\\
+	\item \hyperref[g-recobrimento-regular-def]{G-recobrimento regular};\\
+    \item \hyperref[acao-de-automorfismos-e-livre-prop]{A ação do grupo de automorfismos é livre sobre as fibras};\\
+    \item \hyperref[acao-de-automorfismo-transitiva-prop]{Quando a ação do grupo de automorfismos é transitiva sobre as fibras?};
+\end{titlemize}
+
+Antes de enunciar o teorema, lembramos que um modelo conjuntista para o recobrimento universal $\tilde X$ é o conjunto $\{[\gamma] \; | \; \gamma:I \longrightarrow X \; e \; \gamma (0) = x_0\}$, e que $p: \tilde X \longrightarrow X$ é dada por $p([\gamma]) = \gamma(1)$.
+
+\begin{thm}[G-recobrimentos 0-conexos e epimorfismos do grupo fundamental em G]
+    Sejam $Epi(\pi_1(X, x_0), G)$ o conjunto dos epimorfismos do grupo fundamental de $X$ sobre um grupo $G$ e seja $Cov_G^0(X, x_0)$ o conjunto dos G-recobrimentos regulares pontuados 0-conexos de X, então existe uma correspondência biunívoca entre esses conjuntos a menos de um único homeomorfismo entre os recobrimentos.
+\end{thm}
+
+\begin{dem}
+    Primeiramente tome $\phi \in Epi(\pi_1(X, x_0), G)$, defina $E_{\phi} = \frac{(\tilde X, [c_{x_0}])}{Ker(\phi)}$ e $e_0 = \overline{[c_{x_0}]}$. Defina ainda $q:(E_{\phi}, e_0) \longrightarrow (X, x_0)$ por: $$q(\overline{[\gamma]}) = p([\gamma]) = \gamma(1).$$
+
+    Note que $q$ está bem definida, pois dados $\overline{[\gamma]} = \overline{[\gamma']}$, então existe $[\alpha] \in Ker(\phi)$ tal que: $$[\gamma'] = [\alpha] \cdot [\gamma] = [\gamma * \alpha]$$ de modo que: $$q([\gamma']) = \gamma'(1) = (\gamma * \alpha)(1) = \gamma(1) = q([\gamma])$$
+
+    Como $p: (\tilde X, \tilde x_0) \longrightarrow (X, x_0)$ é um recobrimento e $q(\overline{[\gamma]}) = p([\gamma])$,  então $q:(E_{\phi}, e_0) \longrightarrow (X, x_0)$ é recobrimento. Além disso, como $\tilde X$ é $1$-conexo, então dados $[\gamma], [\gamma'] \in \tilde X$, temos que existe $\Gamma: I \longrightarrow \tilde X$ tal que $\Gamma(0) = [\gamma]$ e $\Gamma(1) = [\gamma']$. Defina $\overline{\Gamma}: I \longrightarrow E_{\phi}$ por $\overline{\Gamma}(t) = \overline{\Gamma(t)}$, então $\overline{\Gamma}(0) = \overline{[\gamma]}$ e $\overline{\Gamma}(1) = \overline{[\gamma']}$ e segue que $E_{\phi}$ é $0$-conexo.
+
+    Pelo teorema dos isomorfismos, sabemos que $ker(\phi) \triangleleft \pi_1(X, x_0)$ e $G \cong \frac{\pi_1(X, x_0)}{Ker(\phi)}$. Notando que $Ker(\phi) = q_*(\pi_1(E_{\phi}, e_0))$, segue que $G \cong Aut(E_{\phi}, q, e_0)$ e o recobrimento é G-regular, concluindo a primeira parte da demonstração.
+
+    Em sequência, tome um G-recobrimento $0$-conexo regular pontuado $q:(E, e_0) \longrightarrow (X, x_0)$ e defina $\phi_{(E, e_0)}: \pi_1(X, x_0) \longrightarrow G$ onde $\phi_{(E, e_0)}([\alpha]) = g$ quando $\tilde \alpha_{e_0}(1) = g \cdot e_0$, já vimos que esta função está bem definida e é um epimorfismo em \hyperref[acao-de-automorfismo-transitiva-prop]{"Quando a ação do grupo de automorfismos é transitiva sobre as fibras?"}, concluindo a segunda parte da demonstração.
+
+    Por fim, sejam $\phi_{(E, e_0)} = \phi_{(E', e_0')}$ e $K = Ker(\phi_{(E, e_0)}) = Ker(\phi_{(E', e_0')})$, já sabemos que $(E, e_0) \cong (\frac{\tilde X}{K}, \overline{[c_{x_0}]}) \cong (E', e_0')$, de modo que vale o seguinte diagrama:
+
+    % https://q.uiver.app/#q=WzAsNCxbMiwwLCIoXFxmcmFje1xcdGlsZGUgWH17S30sIFxcb3ZlcmxpbmV7W2Nfe3hfMH1dfSkiXSxbNCwwLCIoRScsIGVfMCcpIl0sWzAsMCwiKEUsZV8wKSJdLFsyLDMsIlgiXSxbMCwyLCJcXGNvbmciLDJdLFswLDEsIlxcY29uZyJdLFsxLDMsInEnIl0sWzAsMywiXFx0aWxkZSBxIl0sWzIsMywicSIsMl1d
+    \[\begin{tikzcd}
+    	{(E,e_0)} && {(\frac{\tilde X}{K}, \overline{[c_{x_0}]})} && {(E', e_0')} \\
+    	\\
+    	\\
+    	&& X
+    	\arrow["q"', from=1-1, to=4-3]
+    	\arrow["\cong"', from=1-3, to=1-1]
+    	\arrow["\cong", from=1-3, to=1-5]
+    	\arrow["{\tilde q}", from=1-3, to=4-3]
+    	\arrow["{q'}", from=1-5, to=4-3]
+    \end{tikzcd}\]
+
+    Logo, ambos os homeomorfismos são levantamentos de $\tilde q$, de forma que o contexto de espaços pontuados nos garante suas unicidades. Portanto  , existe um único homeomorfismo entre $(E, e_0)$ e $(E', e_0')$.
+\end{dem}
+
+\begin{titlemize}{Lista de consequências}
+	\item \hyperref[consequencia1]{Consequência 1};\\ %'consequencia1' é o label onde o conceito Consequência 1 aparece
+	\item \hyperref[]{}
+\end{titlemize}

--- a/conteudo/seifert-van-kampen-g-recobrimento-def.tex
+++ b/conteudo/seifert-van-kampen-g-recobrimento-def.tex
@@ -9,8 +9,5 @@
 \end{defi}
 
 \begin{titlemize}{Lista de consequências}
-	\item \hyperref[consequencia1]{Consequência 1};\\ %'consequencia1' é o label onde o conceito Consequência 1 aparece
-	\item \hyperref[]{}
+	\item \hyperref[g-recobrimentos-e-epimorfismos-prop]{G-recobrimentos 0-conexos e epimorfismos do grupo fundamental em G};
 \end{titlemize}
-
-%[Bianca]: é mais fácil criar a lista de dependências do que a de consequências.

--- a/conteudo/seifert-van-kampen-g-recobrimento-def.tex
+++ b/conteudo/seifert-van-kampen-g-recobrimento-def.tex
@@ -1,0 +1,16 @@
+%---------------------------------------------------------------------------------------------------------------------!Draft!-----------------------------------------------------------------------------------------------------------------
+\subsection{G-recobrimento regular}
+\label{g-recobrimento-regular-def}
+\begin{titlemize}{Lista de dependências}
+	\item \hyperref[automorfismo-de-recobrimento-def]{Automorfismo de um recobrimento};
+\end{titlemize}
+\begin{defi}[G-recobrimento regular]
+	Um G-recobrimento regular, ou recobrimento G-regular ou ainda recobrimento G-normal de X é um recobrimento $q:E \longrightarrow X$ tal que $Aut(E, q, X) = G$, e a ação $G \circlearrowright q^{-1}(x)$ é livre e transitiva $\forall x \in X$.
+\end{defi}
+
+\begin{titlemize}{Lista de consequências}
+	\item \hyperref[consequencia1]{Consequência 1};\\ %'consequencia1' é o label onde o conceito Consequência 1 aparece
+	\item \hyperref[]{}
+\end{titlemize}
+
+%[Bianca]: é mais fácil criar a lista de dependências do que a de consequências.

--- a/conteudo/seifert-van-kampen-g-recobrimento-def.tex
+++ b/conteudo/seifert-van-kampen-g-recobrimento-def.tex
@@ -9,5 +9,6 @@
 \end{defi}
 
 \begin{titlemize}{Lista de consequências}
-	\item \hyperref[g-recobrimentos-e-epimorfismos-prop]{G-recobrimentos 0-conexos e epimorfismos do grupo fundamental em G};
+	\item \hyperref[g-recobrimentos-e-epimorfismos-prop]{G-recobrimentos 0-conexos e epimorfismos do grupo fundamental em G};\\
+    	\item \hyperref[homomorfismos-e-g-recobrimentos-prop]{G-recobrimentos e homomorfismos do grupo fundamental};
 \end{titlemize}

--- a/conteudo/seifert-van-kampen-homomorfismos-e-g-recobrimentos.tex
+++ b/conteudo/seifert-van-kampen-homomorfismos-e-g-recobrimentos.tex
@@ -1,0 +1,54 @@
+\subsection{G-recobrimentos e homomorfismos do grupo fundamental em G}
+\label{homomorfismos-e-g-recobrimentos-prop}
+\begin{titlemize}{Lista de dependências}
+    \item \hyperref[acao-de-automorfismos-e-livre-prop]{A ação do grupo de automorfismos é livre sobre as fibras};\\
+    \item \hyperref[acao-de-automorfismo-transitiva-prop]{Quando a ação do grupo de automorfismos é transitiva sobre as fibras?};\\
+    \item \hyperref[g-recobrimento-regular-def]{G-recobrimento regular};\\
+	\item \hyperref[g-recobrimentos-e-epimorfismos-prop]{G-recobrimentos 0-conexos e epimorfismos do grupo fundamental em G};
+\end{titlemize}
+
+Em \hyperref[g-recobrimentos-e-epimorfismos-prop]{"G-recobrimentos 0-conexos e epimorfismos do grupo fundamental em G"} vimos que para todo $G$-recobrimento regular $0$-conexo $q:(E, e_0) \longrightarrow (X, x_0)$ existe um epimorfismo do grupo fundamental $\pi_1(X, x_0)$ em $G$. Ainda, se $K$ é o kernel desse epimorfismo, então $G \cong \frac{\pi_1(X, x_0)}{K}$ e $E$ é o quociente de $\tilde X$ pela ação de $K$, com $e_0$ sendo a imagem de $\tilde x_0$. Queremos estender essa correspondência para $G$-recobrimentos não necessariamente $0$-conexos, nesse caso obteremos homomorfismos de $\pi_1(X, x_0)$ em $G$ não necessariamente sobrejetores.
+
+Suponha que $\phi: \pi_1(X, x_0) \longrightarrow G$ é um homomorfismo para algum grupo $G$. De a $G$ a topologia discreta, então o produto cartesiano $\tilde X \times G$ é um produto de cópias de $\tilde X$, uma para cade elemento de $G$. O grupo $\pi_1(X, x_0)$ age em $\tilde X \times G$ segundo a regra: $$[\alpha] \cdot (\tilde x, g) = ([\alpha] \cdot \tilde x, g \cdot \phi([\alpha]^{-1})),$$ onde $[\alpha] \in \pi_1(X, x_0)$, $\tilde x \in \tilde X$ e $g \in G$. Aqui, $[\alpha] \cdot \tilde x$ representa a ação de $\pi_1(X, x_0)$ sobre $\tilde X$ e $g \cdot \phi([\alpha]^{-1})$ é o produto em $G$.
+
+Defina $E_{\phi}$ como o quociente de $\tilde X \times G$ por essa ação: $$E_{\phi} = \frac{\tilde X \times G}{\pi_1(X, x_0)}$$ e seja $e_0$ e imagem de $(\tilde x_0, e)$. Denote por $\langle \tilde x, g \rangle$ a imagem em $E_{\phi}$ de $(\tilde x, g)$. Note que, dada ação de $\pi_1(X, x_0)$ em $\tilde X \times G$, para $\tilde x \in \tilde X$, $g \in G$ e $[\alpha] \in \pi_1(X, x_0)$, temos: $$\langle [\alpha] \cdot (\tilde x, g) \rangle = \langle \tilde x, g \cdot \phi([\alpha]) \rangle.$$ Defina $q_{\phi}: E_{\phi} \longrightarrow X$ por $q_{\phi}(\langle \tilde x, g \rangle) = p(\tilde x)$. Note que por $p: \tilde X \longrightarrow X$ ser um recobrimento, essa definição nos garante que $q_{\phi}:E_{\phi} \longrightarrow X$ também é um recobrimento.
+
+O grupo $G$ age em $E_{\phi}$ pela fórmula $h \cdot \langle \tilde x, g \rangle = \langle \tilde x, h \cdot g \rangle$, para $g, h \in G$ e $\tilde x \in \tilde X$. Note que usamos o lado direito de $G$ para a ação de $\pi_1(X, x_0)$, de modo que o lado esquerdo de $G$ ficou livre para a ação de $G$. Veremos a seguir que essa é uma ação propriamente descontínua de modo que, pelos resultados apresentados em \hyperref[acao-de-automorfismos-e-livre-prop]{"A ação do grupo de automorfismos é livre sobre as fibras"} e \hyperref[acao-de-automorfismo-transitiva-prop]{"Quando a ação do grupo de automorfismos é transitiva sobre as fibras?"}, o recobrimento se trata de um G-recobrimento.
+
+Seja $N$ qualquer subconjunto de $X$ sobre o qual o recobrimento universal é trivial, então existe um isomorfismo de $p^{-1}(N)$ com o recobrimento produto $N \times \pi_1(X, x_0)$, onde $\pi_1(X, x_0)$ age a esquerda no segundo fator. Isso nos dá homeomorfismos: $$q_{\phi}^{-1}(N) \cong (N \times \pi_1(X, x_0)) \times \frac{G}{\pi_1(X, x_0)} \cong N \times G,$$ onde o último homeomorfismo é dado por $\langle (n, [\alpha]), g \rangle \mapsto (n, g \cdot \phi([\alpha]))$, com o mapa inverso sendo $(n, g) \mapsto \langle (n, e), g \rangle$. Esse homeomorfismos são compatíveis com as projeções para $N$, donde segue que, sobre $N$, a ação de $G$ é propriamente descontínua. Como $X$ é coberto por conjuntos abertos como $N$, o mesmo é verdade para o mapa $q_{\phi}:E_{\phi} \longrightarrow X$.
+
+Por outro lado, suponha que $q: (E, e_0) \longrightarrow (X, x_0)$ é um $G$-recobrimento regular pontuado, construiremos um homomorfismo $\phi:\pi_1(X, x_0) \longrightarrow G$. Para cada $[\alpha] \in \pi_1(X, x_0)$, o elemento $\phi([\alpha]) \in G$ será determinado por: $$\phi([\alpha]) = g \Longleftrightarrow g \cdot e_0 = \tilde \alpha_{e_0}(1).$$ Em \hyperref[acao-de-automorfismo-transitiva-prop]{"Quando a ação do grupo de automorfismos é transitiva sobre as fibras?"}, sob a hipótese adicional de $E$ ser $0$-conexo, vimos que esse mapa está bem definido e é um epimorfismo. Notando que a hipótese adicional foi utilizada apenas para mostrar que $\phi$ é sobrejetor, segue que $\phi$ está bem definido e é um homomorfismo.
+
+\begin{thm}[Correspondência entre G-recobrimentos e homomorfismos do grupo fundamental em G]
+	As construções acima determinam uma correspondência biunívoca entre o conjunto dos homomorfismos de $\pi_1(X, x_0)$ em $G$ e o conjunto de $G$-recobrimentos regulares pontuados, a menos de isomorfismo.
+\end{thm}
+
+\begin{dem}
+    Dado um G-recobrimento regular $q:(E, e_0) \longrightarrow (X, x_0)$ e o homomorfismo $\phi: \pi_1(X, x_0) \longrightarrow G$ construído a partir dele, precisamos checar que este recobrimento é isomorfo ao recobrimento $q_{\phi}:E_{\phi} \longrightarrow X$ construído a partir de $\phi$. Para mapear $E_{\phi}$ em $E$, precisamos mapear $\tilde X \times G$ em $E$ e mostrar que as órbitas de $\pi_1(X, x_0)$ tem as mesmas imagens. Para tanto, identificamos o recobrimento universal $\tilde X$ com o espaço de classes de homotopia de caminhos em $X$ começando em $x_0$, $\tilde X \cong \{[\gamma] \; | \; \gamma:I \longrightarrow X, \; \gamma(0) = x_0\}$. Defina o aplicação contínua $\tilde X \times G \longrightarrow E$ por: $$([\gamma], g) \longmapsto g \cdot \tilde \gamma_{e_0}(1) = \tilde \gamma_{g \cdot e_0}(1).$$
+
+    Precisamos checar que que o ponto equivalente $(([\alpha]\cdot[\gamma]),(g\cdot\phi([\alpha])^{-1}))$ é levado à mesma imagem. Note que:\\
+        $$\begin{tabular}{l l}
+            $(g\cdot\phi([\alpha])^{-1}) \cdot \widetilde{(\gamma * \alpha)}_{e_0}(1)$ & $= (g\cdot\phi([\alpha])^{-1}) \cdot \tilde\gamma_{\tilde\alpha_{e_0}(1)}(1)$\\
+                 & $= \tilde\gamma_{(g\cdot\phi([\alpha])^{-1}) \cdot \tilde\alpha_{e_0}(1)}(1)$\\
+                 & $= \tilde\gamma_{g \cdot \alpha^{-1}_{\alpha_{e_0}}(1)}(1)$\\
+                 & $= \tilde\gamma_{g\cdot(\alpha*\alpha^{-1})_{e_0}(1)}(1)$\\
+                 & $= \tilde\gamma_{g \cdot e_0}(1).$
+        \end{tabular}$$\\
+
+    Como a aplicação leva pontos equivalentes às mesmas imagens, ela da origem a um mapa do quociente $E_{\phi}$ a $E$, que é um mapa entre espaços de recobrimento de $X$. É fácil checar que se trata de um mapa entre $G$-recobrimentos regulares, donde segue que se trata de um isomorfismo.
+
+    Por outro lado, partindo de um homomorfismo $\phi$ e do $G$-recobrimento regular $q_{\phi}: E_{\phi} \longrightarrow X$ construído a partir dele, obtemos um novo homomorfismo $\overline{\phi}$, precisamos verificar que $\phi = \overline{\phi}$. Para $[\alpha] \in \pi_1(X, x_0)$:\\
+        $$\begin{tabular}{l l}
+            $\overline{\phi}([\alpha]) \cdot \langle \tilde x_0, e \rangle$ 
+                            & $= \tilde\alpha_{\langle \tilde x_0, e \rangle}(1)$\\
+                            & $= \langle \tilde\alpha_{\tilde x_0}(1), e \rangle$\\
+                            & $= \langle [\alpha] \cdot \tilde x_0, e \rangle$\\
+                            & $= \langle \tilde x_0, e \cdot \phi([\alpha]) \rangle$\\
+                            & $= \phi([\alpha]) \cdot \langle \tilde x_0, e \rangle$
+        \end{tabular}$$\\
+    donde temos que $\phi([\alpha]) = \overline{\phi}([\alpha])$.
+\end{dem}
+
+\begin{titlemize}{Lista de consequências}
+	\item \hyperref[seifert-van-kampen-prop]{Teorema de Seifert-Van Kampen};
+\end{titlemize}

--- a/conteudo/seifert-van-kampen-n-esfera-1-conexa-ex.tex
+++ b/conteudo/seifert-van-kampen-n-esfera-1-conexa-ex.tex
@@ -1,0 +1,29 @@
+\subsection{A n-esfera é 1-conexa para $n \geq 2$}
+\label{n-esfera-1-conexa-ex}
+\begin{titlemize}{Lista de dependências}
+	\item \hyperref[seifert-van-kampen-prop]{Teorena de Seifert-Van Kampen};
+\end{titlemize}
+
+Suponha que temos o seguinte diagrama:
+% https://q.uiver.app/#q=WzAsNSxbMCwxLCJOIl0sWzEsMCwiXFx7ZVxcfSJdLFsxLDIsIlxce2VcXH0iXSxbMiwxLCJHIl0sWzQsMSwiSCJdLFsxLDMsImpfMSIsMl0sWzIsMywial8yIl0sWzAsMSwiaV8xIiwyXSxbMCwyLCJpXzIiXSxbMyw0LCJoIiwwLHsic3R5bGUiOnsiYm9keSI6eyJuYW1lIjoiZGFzaGVkIn19fV0sWzEsNCwiaF8xIl0sWzIsNCwiaF8yIl1d
+\[\begin{tikzcd}
+	& {\{e\}} \\
+	N && G && H \\
+	& {\{e\}}
+	\arrow["{j_1}"', from=1-2, to=2-3]
+	\arrow["{h_1}", from=1-2, to=2-5]
+	\arrow["{i_1}"', from=2-1, to=1-2]
+	\arrow["{i_2}", from=2-1, to=3-2]
+	\arrow["h", dashed, from=2-3, to=2-5]
+	\arrow["{j_2}", from=3-2, to=2-3]
+	\arrow["{h_2}"', from=3-2, to=2-5]
+\end{tikzcd}\]
+onde $(G, j_1, j_2)$ satisfazem a propriedade universal do teorema de Seifert-Van Kampen. Note que para qualquer grupo $G$, os homomorfismos $j_1$ e $j_2$ estão fixos e são dados por $j_1(e) = e_G = j_2(e)$. Note ainda que $$(h \circ j_1)(e) = h(j_1(e)) = h(e_G) = e_H = h_1(e)$$ e da mesma forma $$(h \circ j_2)(e) = h_2(e)$$ para qualquer homomorfismo $h:G\longrightarrow H$, logo, para termos a unicidade de $h$ precisamos que $G$ seja um grupo que tenha apenas um homomorfismo para qualquer outro grupo $H$. Portanto, segue que $G = \{e\}$.
+
+\begin{ex}[O grupo fundamental de $S^n$ para $N \geq 2$]
+	Sejam: $$S^n = \{(x_1, \cdots, x_n, t) \in \mathbb{R}^{n+1} \; | \; x_1^2+\cdots+x_n^2+t^2 = 1\}$$ $$U = \{(x_1, \cdots, x_n, t) \in S^n \; | \; t > -1/2\}$$ $$V = \{(x_1, \cdots, x_n, t) \in S^n \; | \; t < 1/2\}$$ $$U \cap V = \{(x_1, \cdots, x_n, t) \in S^n \; | \; -1/2 < t < 1/2\}$$
+
+    Então veja que $U \cong \mathring D^n \cong V$, de modo que $\pi_1(U, x_0) = \pi_1(V, x_0) = \{e\}$ e $U \cap V \cong (-\frac{1}{2}, \frac{1}{2}) \times S^{n-1}$, que é $0$-conexo. Logo, pelo discutido acima, segue que $\pi_1(S^n, x_0) = \{e\}$.
+\end{ex}
+
+Disso, vemos que a n-esfera, para $n \geq 2$, é $1$-conexa.

--- a/conteudo/seifert-van-kampen-prop.tex
+++ b/conteudo/seifert-van-kampen-prop.tex
@@ -50,8 +50,5 @@ Iremos determinar o grupo $\pi_1(X, x_0)$ a partir dos outros grupos e dos mapas
 \end{dem}
 
 \begin{titlemize}{Lista de consequências}
-	\item \hyperref[consequencia1]{Consequência 1};\\ %'consequencia1' é o label onde o conceito Consequência 1 aparece
-	\item \hyperref[]{}
+	\item \hyperref[n-esfera-1-conexa-ex]{A n-esfera é 1-conexa};
 \end{titlemize}
-
-%[Bianca]: Um arquivo tex pode ter mais de uma afirmação (ou definição, ou exemplo), mas nesse caso cada afirmação deve ter seu próprio label. Dar preferência para agrupar afirmações que dependam entre sí de maneira próxima (um teorema e seu corolário, por exemplo)

--- a/conteudo/seifert-van-kampen-prop.tex
+++ b/conteudo/seifert-van-kampen-prop.tex
@@ -46,5 +46,5 @@ Iremos determinar o grupo $\pi_1(X, x_0)$ a partir dos outros grupos e dos mapas
 \end{dem}
 
 \begin{titlemize}{Lista de consequências}
-	\item \hyperref[n-esfera-1-conexa-ex]{A n-esfera é 1-conexa};
+	\item \hyperref[n-esfera-1-conexa-ex]{A n-esfera é 1-conexa para $n \geq 2$};
 \end{titlemize}

--- a/conteudo/seifert-van-kampen-prop.tex
+++ b/conteudo/seifert-van-kampen-prop.tex
@@ -7,17 +7,15 @@
 
 O teorema de Seifert-Van Kampen descreve o grupo fundamental da união de dois espaços em termos do grupo fundamental de cada um desses espaços e de sua intersecção. Seja $X$ um espaço que é a união de dois subespaços abertos $U$ e $V$. Seja $x_0$ um ponto da intersecção $U \cap V$. Temos o seguinte diagrama comutativo de homomorfismos dos grupos fundamentais:
 
-% https://q.uiver.app/#q=WzAsNCxbMCwyLCJcXHBpXzEoVSBcXGNhcCBWLCB4XzApIl0sWzIsMCwiXFxwaV8xKFUsIHhfMCkiXSxbNCwyLCJcXHBpXzEoWCwgeF8wKSJdLFsyLDQsIlxccGlfMShWLCB4XzApIl0sWzMsMiwial97ViwgKn0iXSxbMSwyLCJqX3tVLCAqfSIsMl0sWzAsMSwiaV97VSwgKn0iLDJdLFswLDMsImlfe1YsICp9Il1d
+% https://q.uiver.app/#q=WzAsNCxbMCwxLCJcXHBpXzEoVSBcXGNhcCBWLCB4XzApIl0sWzEsMCwiXFxwaV8xKFUsIHhfMCkiXSxbMiwxLCJcXHBpXzEoWCwgeF8wKSJdLFsxLDIsIlxccGlfMShWLCB4XzApIl0sWzMsMiwial97ViwgKn0iXSxbMSwyLCJqX3tVLCAqfSIsMl0sWzAsMSwiaV97VSwgKn0iLDJdLFswLDMsImlfe1YsICp9Il1d
 \[\begin{tikzcd}
-	&& {\pi_1(U, x_0)} \\
-	\\
-	{\pi_1(U \cap V, x_0)} &&&& {\pi_1(X, x_0)} \\
-	\\
-	&& {\pi_1(V, x_0)}
-	\arrow["{j_{U, *}}"', from=1-3, to=3-5]
-	\arrow["{i_{U, *}}"', from=3-1, to=1-3]
-	\arrow["{i_{V, *}}", from=3-1, to=5-3]
-	\arrow["{j_{V, *}}", from=5-3, to=3-5]
+	& {\pi_1(U, x_0)} \\
+	{\pi_1(U \cap V, x_0)} && {\pi_1(X, x_0)} \\
+	& {\pi_1(V, x_0)}
+	\arrow["{j_{U, *}}"', from=1-2, to=2-3]
+	\arrow["{i_{U, *}}"', from=2-1, to=1-2]
+	\arrow["{i_{V, *}}", from=2-1, to=3-2]
+	\arrow["{j_{V, *}}", from=3-2, to=2-3]
 \end{tikzcd}\]
 onde os mapas são induzidos pelas inclusões de subespaço.
 
@@ -27,20 +25,18 @@ Iremos determinar o grupo $\pi_1(X, x_0)$ a partir dos outros grupos e dos mapas
 	Para quaisquer homomorfismos $h_U:\pi_1(U, x_0) \longrightarrow G$ e $h_V:\pi_1(V, x_0) \longrightarrow G$ tais que $h_U \circ i_{U, *} = h_V \circ i_{V, *}$, existe um único homomorfismo: $$h:\pi_1(X, x_0) \longrightarrow G$$ tal que $h \circ j_{U, *} = h_U$ e $h \circ j_{V, *} = h_V$.
 \end{thm}
 
-% https://q.uiver.app/#q=WzAsNSxbMCwyLCJcXHBpXzEoVSBcXGNhcCBWLCB4XzApIl0sWzIsMCwiXFxwaV8xKFUsIHhfMCkiXSxbNCwyLCJcXHBpXzEoWCwgeF8wKSJdLFsyLDQsIlxccGlfMShWLCB4XzApIl0sWzcsMiwiRyJdLFszLDIsImpfe1YsICp9Il0sWzEsMiwial97VSwgKn0iLDJdLFswLDEsImlfe1UsICp9IiwyXSxbMCwzLCJpX3tWLCAqfSJdLFsyLDQsImgiLDIseyJzdHlsZSI6eyJib2R5Ijp7Im5hbWUiOiJkYXNoZWQifX19XSxbMSw0LCJoX1UiXSxbMyw0LCJoX1YiLDJdXQ==
+% https://q.uiver.app/#q=WzAsNSxbMCwxLCJOIl0sWzEsMCwiXFx7ZVxcfSJdLFsxLDIsIlxce2VcXH0iXSxbMiwxLCJHIl0sWzQsMSwiSCJdLFsxLDMsImpfMSIsMl0sWzIsMywial8yIl0sWzAsMSwiaV8xIiwyXSxbMCwyLCJpXzIiXSxbMyw0LCJoIiwwLHsic3R5bGUiOnsiYm9keSI6eyJuYW1lIjoiZGFzaGVkIn19fV0sWzEsNCwiaF8xIl0sWzIsNCwiaF8yIl1d
 \[\begin{tikzcd}
-	&& {\pi_1(U, x_0)} \\
-	\\
-	{\pi_1(U \cap V, x_0)} &&&& {\pi_1(X, x_0)} &&& G \\
-	\\
-	&& {\pi_1(V, x_0)}
-	\arrow["{j_{U, *}}"', from=1-3, to=3-5]
-	\arrow["{h_U}", from=1-3, to=3-8]
-	\arrow["{i_{U, *}}"', from=3-1, to=1-3]
-	\arrow["{i_{V, *}}", from=3-1, to=5-3]
-	\arrow["h"', dashed, from=3-5, to=3-8]
-	\arrow["{j_{V, *}}", from=5-3, to=3-5]
-	\arrow["{h_V}"', from=5-3, to=3-8]
+	& {\{e\}} \\
+	N && G && H \\
+	& {\{e\}}
+	\arrow["{j_1}"', from=1-2, to=2-3]
+	\arrow["{h_1}", from=1-2, to=2-5]
+	\arrow["{i_1}"', from=2-1, to=1-2]
+	\arrow["{i_2}", from=2-1, to=3-2]
+	\arrow["h", dashed, from=2-3, to=2-5]
+	\arrow["{j_2}", from=3-2, to=2-3]
+	\arrow["{h_2}", from=3-2, to=2-5]
 \end{tikzcd}\]
 
 \begin{dem}

--- a/conteudo/seifert-van-kampen-prop.tex
+++ b/conteudo/seifert-van-kampen-prop.tex
@@ -1,0 +1,57 @@
+\subsection{Teorema de Seifert-Van Kampen}
+\label{seifert-van-kampen-prop}
+\begin{titlemize}{Lista de dependências}
+	\item \hyperref[homomorfismos-e-g-recobrimentos-prop]{G-recobrimentos e homomorfismos do grupo fundamental em G};\\
+	\item \hyperref[colagem-de-recobrimentos-prop]{Colagem de recobrimentos};
+\end{titlemize}
+
+O teorema de Seifert-Van Kampen descreve o grupo fundamental da união de dois espaços em termos do grupo fundamental de cada um desses espaços e de sua intersecção. Seja $X$ um espaço que é a união de dois subespaços abertos $U$ e $V$. Seja $x_0$ um ponto da intersecção $U \cap V$. Temos o seguinte diagrama comutativo de homomorfismos dos grupos fundamentais:
+
+% https://q.uiver.app/#q=WzAsNCxbMCwyLCJcXHBpXzEoVSBcXGNhcCBWLCB4XzApIl0sWzIsMCwiXFxwaV8xKFUsIHhfMCkiXSxbNCwyLCJcXHBpXzEoWCwgeF8wKSJdLFsyLDQsIlxccGlfMShWLCB4XzApIl0sWzMsMiwial97ViwgKn0iXSxbMSwyLCJqX3tVLCAqfSIsMl0sWzAsMSwiaV97VSwgKn0iLDJdLFswLDMsImlfe1YsICp9Il1d
+\[\begin{tikzcd}
+	&& {\pi_1(U, x_0)} \\
+	\\
+	{\pi_1(U \cap V, x_0)} &&&& {\pi_1(X, x_0)} \\
+	\\
+	&& {\pi_1(V, x_0)}
+	\arrow["{j_{U, *}}"', from=1-3, to=3-5]
+	\arrow["{i_{U, *}}"', from=3-1, to=1-3]
+	\arrow["{i_{V, *}}", from=3-1, to=5-3]
+	\arrow["{j_{V, *}}", from=5-3, to=3-5]
+\end{tikzcd}\]
+onde os mapas são induzidos pelas inclusões de subespaço.
+
+Iremos determinar o grupo $\pi_1(X, x_0)$ a partir dos outros grupos e dos mapas entre eles a partir de uma propriedade universal. Note que qualquer homomorfismo $h$ de $\pi_1(X, x_0)$ para $G$ determina um par de homomorfismos $h_U = h \circ j_{U, *}$ de $\pi_1(U, x_0)$ para G e $h_V = h \circ j_{V, *}$ de $\pi_1(V, x_0)$ para $G$. Os dois homomorfismos $h_U \circ i_{U, *}$ e $h_V \circ i_{V, *}$ de $\pi_1(U \cap V, x_0)$ para $G$ são o mesmo. O teorema de Seifert-Van Kampen diz que $\pi_1(X, x_0)$ é o grupo "universal" com essa propriedade.
+
+\begin{thm}[Seifert-Van Kampen] 
+	Para quaisquer homomorfismos $h_U:\pi_1(U, x_0) \longrightarrow G$ e $h_V:\pi_1(V, x_0) \longrightarrow G$ tais que $h_U \circ i_{U, *} = h_V \circ i_{V, *}$, existe um único homomorfismo: $$h:\pi_1(X, x_0) \longrightarrow G$$ tal que $h \circ j_{U, *} = h_U$ e $h \circ j_{V, *} = h_V$.
+\end{thm}
+
+% https://q.uiver.app/#q=WzAsNSxbMCwyLCJcXHBpXzEoVSBcXGNhcCBWLCB4XzApIl0sWzIsMCwiXFxwaV8xKFUsIHhfMCkiXSxbNCwyLCJcXHBpXzEoWCwgeF8wKSJdLFsyLDQsIlxccGlfMShWLCB4XzApIl0sWzcsMiwiRyJdLFszLDIsImpfe1YsICp9Il0sWzEsMiwial97VSwgKn0iLDJdLFswLDEsImlfe1UsICp9IiwyXSxbMCwzLCJpX3tWLCAqfSJdLFsyLDQsImgiLDIseyJzdHlsZSI6eyJib2R5Ijp7Im5hbWUiOiJkYXNoZWQifX19XSxbMSw0LCJoX1UiXSxbMyw0LCJoX1YiLDJdXQ==
+\[\begin{tikzcd}
+	&& {\pi_1(U, x_0)} \\
+	\\
+	{\pi_1(U \cap V, x_0)} &&&& {\pi_1(X, x_0)} &&& G \\
+	\\
+	&& {\pi_1(V, x_0)}
+	\arrow["{j_{U, *}}"', from=1-3, to=3-5]
+	\arrow["{h_U}", from=1-3, to=3-8]
+	\arrow["{i_{U, *}}"', from=3-1, to=1-3]
+	\arrow["{i_{V, *}}", from=3-1, to=5-3]
+	\arrow["h"', dashed, from=3-5, to=3-8]
+	\arrow["{j_{V, *}}", from=5-3, to=3-5]
+	\arrow["{h_V}"', from=5-3, to=3-8]
+\end{tikzcd}\]
+
+\begin{dem}
+    Considere um grupo $G$ e um par de homomorfismos $h_U$ e $h_V$ como nas hipóteses do teorema. Pelo resultado em \hyperref[homomorfismos-e-g-recobrimentos-prop]{"G-recobrimentos e homomorfismos do grupo fundamental em G"}, podemos associar aos homomorfismos $h_U$ e $h_V$ $G$-recobrimentos regulares $q_U:(E_U,e_{U, 0}) \longrightarrow (U, x_0)$ e $q_V:(E_V,e_{V, 0}) \longrightarrow (V, x_0)$. Para $k = U, V$, seja $Y_k = q_k^{-1}(U \cap V)$, de forma que $(Y_k, y_{k, 0}) \longrightarrow (U \cap V, x_0)$ é um $G$-recobrimento regular representando o homomorfismo: $$h_k \circ i_{k, *}:  \pi_1(U \cap V, x_0) \longrightarrow \pi_1(k, x_0) \longrightarrow G$$
+
+    Como os homomorfismos $h_U \circ i_{U, *}$ e $h_V \circ i_{V, *}$ são iguais, temos que $(Y_U, y_{U, 0}) \longrightarrow (U \cap V, x_0)$ e $(Y_V, y_{V, 0}) \longrightarrow (U \cap V, x_0)$ são $G$-recobrimentos regulares isomorfos, logo existe um único homeomorfismo $\varphi: (Y_U, y_{U, 0}) \longrightarrow (Y_V, y_{V, 0})$. Pelo visto em \hyperref[colagem-de-recobrimentos-prop]{"Colagem de recobrimentos"}, podemos colar $q_U$ e $q_V$ de forma a obter um G-recobrimento regular $q:(E, e_0) \longrightarrow (X, x_0)$. Usando novamente o resultado de \hyperref[homomorfismos-e-g-recobrimentos-prop]{"G-recobrimentos e homomorfismos do grupo fundamental em G"} vemos que esse recobrimento representa o homomorfismo $h$ desejado. A unicidade de $h$ decorre da unicidade de todos os passos realizados.
+\end{dem}
+
+\begin{titlemize}{Lista de consequências}
+	\item \hyperref[consequencia1]{Consequência 1};\\ %'consequencia1' é o label onde o conceito Consequência 1 aparece
+	\item \hyperref[]{}
+\end{titlemize}
+
+%[Bianca]: Um arquivo tex pode ter mais de uma afirmação (ou definição, ou exemplo), mas nesse caso cada afirmação deve ter seu próprio label. Dar preferência para agrupar afirmações que dependam entre sí de maneira próxima (um teorema e seu corolário, por exemplo)

--- a/conteudo/seifert-van-kampen.tex
+++ b/conteudo/seifert-van-kampen.tex
@@ -16,3 +16,4 @@ A menos que explicitamente mencionado, no que segue assumiremos que o espaço ba
 \input{conteudo/seifert-van-kampen-acao-de-automorfismo-transitiva-prop}
 \input{conteudo/seifert-van-kampen-g-recobrimento-def}
 \input{conteudo/seifert-van-kampen-correspondencia-entre-epimorfismos-e-g-recobrimentos}
+\input{conteudo/seifert-van-kampen-homomorfismos-e-g-recobrimentos}

--- a/conteudo/seifert-van-kampen.tex
+++ b/conteudo/seifert-van-kampen.tex
@@ -13,4 +13,5 @@ O teorema de Seifert-Van Kampen é um importante resultado da topologia algébri
 A menos que explicitamente mencionado, no que segue assumiremos que o espaço base $X$ é razoável, isto é, $X$ é conexo, localmente conexo por caminhos, e localmente semi-simplesmente conexo. Como visto em seções anteriores, $X$ conexo e localmente conexo por caminhos nos garante a exisência e unicidade de levantamentos, $X$ localmente semi-simplesmente conexo nos garante a existência do recobrimento universal, que será denotado por $p:(\tilde X, \tilde x_0) \longrightarrow (X, x_0)$.
 \input{conteudo/seifert-van-kampen-automorfismo-de-recobrimento-def}
 \input{conteudo/seifert-van-kampen-acao-de-automorfismos-e-livre-prop}
+\input{conteudo/seifert-van-kampen-acao-de-automorfismo-transitiva-prop}
 \input{conteudo/seifert-van-kampen-g-recobrimento-def}

--- a/conteudo/seifert-van-kampen.tex
+++ b/conteudo/seifert-van-kampen.tex
@@ -11,4 +11,5 @@
 O teorema de Seifert-Van Kampen é um importante resultado da topologia algébrica que nos permite calcular o grupo fundamental de diversos espaços topológicos razoáveis a partir dos grupos fundamentais de certos subespaços.
 
 A menos que explicitamente mencionado, no que segue assumiremos que o espaço base $X$ é razoável, isto é, $X$ é conexo, localmente conexo por caminhos, e localmente semi-simplesmente conexo. Como visto em seções anteriores, $X$ conexo e localmente conexo por caminhos nos garante a exisência e unicidade de levantamentos, $X$ localmente semi-simplesmente conexo nos garante a existência do recobrimento universal, que será denotado por $p:(\tilde X, \tilde x_0) \longrightarrow (X, x_0)$.
+\input{conteudo/seifert-van-kampen-automorfismo-de-recobrimento-def}
 \input{conteudo/seifert-van-kampen-g-recobrimento-def}

--- a/conteudo/seifert-van-kampen.tex
+++ b/conteudo/seifert-van-kampen.tex
@@ -1,0 +1,14 @@
+\section{Teorema de Seifert-Van Kampen}
+\label{teorema-de-seifert-van-kampen}
+
+\begin{titlemize}{Lista de Dependências}
+	\item \hyperref[grupo-fundamental]{Grupo Fundamental};\\
+	\item \hyperref[espaco-de-recobrimento]{Espaço de recobrimento};\\
+    \item \hyperref[ações-de-grupos-e-recobrimentos]{Ações de grupos e recobrimentos};
+\end{titlemize}
+
+O teorema de Seifert-Van Kampen é um importante resultado da topologia algébrica que nos permite calcular o grupo fundamental de diversos espaços topológicos razoáveis a partir dos grupos fundamentais de certos subespaços.
+
+A menos que explicitamente mencionado, no que segue assumiremos que o espaço base $X$ é razoável, isto é, $X$ é conexo, localmente conexo por caminhos, e localmente semi-simplesmente conexo. Como visto em seções anteriores, $X$ conexo e localmente conexo por caminhos nos garante a exisência e unicidade de levantamentos, $X$ localmente semi-simplesmente conexo nos garante a exisência de um recobrimento 1-conexo.
+
+\input{}

--- a/conteudo/seifert-van-kampen.tex
+++ b/conteudo/seifert-van-kampen.tex
@@ -11,4 +11,4 @@
 O teorema de Seifert-Van Kampen é um importante resultado da topologia algébrica que nos permite calcular o grupo fundamental de diversos espaços topológicos razoáveis a partir dos grupos fundamentais de certos subespaços.
 
 A menos que explicitamente mencionado, no que segue assumiremos que o espaço base $X$ é razoável, isto é, $X$ é conexo, localmente conexo por caminhos, e localmente semi-simplesmente conexo. Como visto em seções anteriores, $X$ conexo e localmente conexo por caminhos nos garante a exisência e unicidade de levantamentos, $X$ localmente semi-simplesmente conexo nos garante a existência do recobrimento universal, que será denotado por $p:(\tilde X, \tilde x_0) \longrightarrow (X, x_0)$.
-\input{}
+\input{conteudo/seifert-van-kampen-g-recobrimento-def}

--- a/conteudo/seifert-van-kampen.tex
+++ b/conteudo/seifert-van-kampen.tex
@@ -19,3 +19,4 @@ A menos que explicitamente mencionado, no que segue assumiremos que o espaço ba
 \input{conteudo/seifert-van-kampen-homomorfismos-e-g-recobrimentos}
 \input{conteudo/seifert-van-kampen-colagem-de-recobrimentos}
 \input{conteudo/seifert-van-kampen-prop}
+\input{conteudo/seifert-van-kampen-n-esfera-1-conexa-ex}

--- a/conteudo/seifert-van-kampen.tex
+++ b/conteudo/seifert-van-kampen.tex
@@ -17,3 +17,4 @@ A menos que explicitamente mencionado, no que segue assumiremos que o espaço ba
 \input{conteudo/seifert-van-kampen-g-recobrimento-def}
 \input{conteudo/seifert-van-kampen-correspondencia-entre-epimorfismos-e-g-recobrimentos}
 \input{conteudo/seifert-van-kampen-homomorfismos-e-g-recobrimentos}
+\input{conteudo/seifert-van-kampen-colagem-de-recobrimentos}

--- a/conteudo/seifert-van-kampen.tex
+++ b/conteudo/seifert-van-kampen.tex
@@ -15,3 +15,4 @@ A menos que explicitamente mencionado, no que segue assumiremos que o espaço ba
 \input{conteudo/seifert-van-kampen-acao-de-automorfismos-e-livre-prop}
 \input{conteudo/seifert-van-kampen-acao-de-automorfismo-transitiva-prop}
 \input{conteudo/seifert-van-kampen-g-recobrimento-def}
+\input{conteudo/seifert-van-kampen-correspondencia-entre-epimorfismos-e-g-recobrimentos}

--- a/conteudo/seifert-van-kampen.tex
+++ b/conteudo/seifert-van-kampen.tex
@@ -4,11 +4,11 @@
 \begin{titlemize}{Lista de Dependências}
 	\item \hyperref[grupo-fundamental]{Grupo Fundamental};\\
 	\item \hyperref[espaco-de-recobrimento]{Espaço de recobrimento};\\
-    \item \hyperref[ações-de-grupos-e-recobrimentos]{Ações de grupos e recobrimentos};
+    	\item \hyperref[ações-de-grupos-e-recobrimentos]{Ações de grupos e recobrimentos};\\
+    	\item \hyperref[recobrimento-universal]{Recobrimento Universal};
 \end{titlemize}
 
 O teorema de Seifert-Van Kampen é um importante resultado da topologia algébrica que nos permite calcular o grupo fundamental de diversos espaços topológicos razoáveis a partir dos grupos fundamentais de certos subespaços.
 
-A menos que explicitamente mencionado, no que segue assumiremos que o espaço base $X$ é razoável, isto é, $X$ é conexo, localmente conexo por caminhos, e localmente semi-simplesmente conexo. Como visto em seções anteriores, $X$ conexo e localmente conexo por caminhos nos garante a exisência e unicidade de levantamentos, $X$ localmente semi-simplesmente conexo nos garante a exisência de um recobrimento 1-conexo.
-
+A menos que explicitamente mencionado, no que segue assumiremos que o espaço base $X$ é razoável, isto é, $X$ é conexo, localmente conexo por caminhos, e localmente semi-simplesmente conexo. Como visto em seções anteriores, $X$ conexo e localmente conexo por caminhos nos garante a exisência e unicidade de levantamentos, $X$ localmente semi-simplesmente conexo nos garante a existência do recobrimento universal, que será denotado por $p:(\tilde X, \tilde x_0) \longrightarrow (X, x_0)$.
 \input{}

--- a/conteudo/seifert-van-kampen.tex
+++ b/conteudo/seifert-van-kampen.tex
@@ -12,4 +12,5 @@ O teorema de Seifert-Van Kampen é um importante resultado da topologia algébri
 
 A menos que explicitamente mencionado, no que segue assumiremos que o espaço base $X$ é razoável, isto é, $X$ é conexo, localmente conexo por caminhos, e localmente semi-simplesmente conexo. Como visto em seções anteriores, $X$ conexo e localmente conexo por caminhos nos garante a exisência e unicidade de levantamentos, $X$ localmente semi-simplesmente conexo nos garante a existência do recobrimento universal, que será denotado por $p:(\tilde X, \tilde x_0) \longrightarrow (X, x_0)$.
 \input{conteudo/seifert-van-kampen-automorfismo-de-recobrimento-def}
+\input{conteudo/seifert-van-kampen-acao-de-automorfismos-e-livre-prop}
 \input{conteudo/seifert-van-kampen-g-recobrimento-def}

--- a/conteudo/seifert-van-kampen.tex
+++ b/conteudo/seifert-van-kampen.tex
@@ -18,3 +18,4 @@ A menos que explicitamente mencionado, no que segue assumiremos que o espaço ba
 \input{conteudo/seifert-van-kampen-correspondencia-entre-epimorfismos-e-g-recobrimentos}
 \input{conteudo/seifert-van-kampen-homomorfismos-e-g-recobrimentos}
 \input{conteudo/seifert-van-kampen-colagem-de-recobrimentos}
+\input{conteudo/seifert-van-kampen-prop}


### PR DESCRIPTION
Adicionei o início de uma nova seção dedicada ao teorema de Seifert-Van Kampen, bem como algumas novas subseções dedicadas a mostrar a unicidade a menos de único isomorfismo do recobrimento 1-conexo de um espaço X razoável. 